### PR TITLE
Setting up Workflow to Run Build Commands

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,10 @@
-name: Build on Main
+name: Build Check
 
 on:
   push:
-    branches:
-      - main
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   build:
@@ -14,12 +15,13 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: '20'
+          cache: 'npm'
 
-      - name: Install dependencies
-        run: npm install
+      - name: Install dependencies (force install to resolve peer conflicts)
+        run: npm install --force
 
       - name: Run build
         run: npm run build


### PR DESCRIPTION
- Using --force tag during installing dependencies to resolve peer dependencies.
- Cache the installed dependencies to speed up consecutive builds
- Run the build during merging to main and when PRs are created to main